### PR TITLE
[auto-merge] bot-auto-merge-branch-22.02 to branch-22.04 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,10 +27,6 @@ env:
 
 jobs:
   auto-merge:
-    env:
-      INTERMEDIATE_HEAD: bot-auto-merge-${{ env.HEAD }}
-      FILE_USE_BASE: thirdparty/cudf
-
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
@@ -49,6 +45,9 @@ jobs:
           [[ ! -z "${OUT}" ]] && git checkout origin/${BASE} -- ${FILE_USE_BASE} && \
             git commit -s -am "Auto-merge use submodule in BASE ref"
           git push origin ${INTERMEDIATE_HEAD} -f
+        env:
+          INTERMEDIATE_HEAD: bot-auto-merge-${{ env.HEAD }}
+          FILE_USE_BASE: thirdparty/cudf
 
       - name: auto-merge job
         uses: ./.github/workflows/action-helper
@@ -57,6 +56,6 @@ jobs:
         env:
           OWNER: pxLi
           REPO: spark-rapids-jni
-          HEAD: ${{ env.INTERMEDIATE_HEAD }}
+          HEAD: bot-auto-merge-${{ env.HEAD }}
           BASE: ${{ env.BASE }}
           TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This repository contains native support code for the
 ## Building From Source
 
 See the [build instructions in the contributing guide](CONTRIBUTING.md#building-from-source).
+

--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ This repository contains native support code for the
 
 See the [build instructions in the contributing guide](CONTRIBUTING.md#building-from-source).
 
+


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-22.02` to create a PR keeping `branch-22.04` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.