### PR TITLE
[auto-merge] bot-auto-merge-branch-22.02 to branch-22.04 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -34,9 +34,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           ref: ${{ env.HEAD }} # force to fetch from latest upstream instead of PR ref
+          token: ${{ secrets.AUTOMERGE_TOKEN }}
 
       - name: push intermediate branch for auto-merge
         run: |
@@ -47,9 +48,9 @@ jobs:
           OUT=$(git --no-pager diff --name-only origin/${BASE} | grep "${FILE_USE_BASE}" || true)
           [[ ! -z "${OUT}" ]] && git checkout origin/${BASE} -- ${FILE_USE_BASE} && \
             git commit -s -am "Auto-merge use submodule in BASE ref"
-          #git push origin ${INTERMEDIATE_HEAD} -f
+          git push origin ${INTERMEDIATE_HEAD} -f
           echo "123321"
-          git push https://nvauto:${{ secrets.AUTOMERGE_TOKEN }}@github.com/pxLi/spark-rapids-jni.git ${INTERMEDIATE_HEAD} -f
+          #git push https://nvauto:${{ secrets.AUTOMERGE_TOKEN }}@github.com/pxLi/spark-rapids-jni.git ${INTERMEDIATE_HEAD} -f
         env:
           INTERMEDIATE_HEAD: bot-auto-merge-${{ env.HEAD }}
           FILE_USE_BASE: thirdparty/cudf

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,7 +26,7 @@ env:
   BASE: branch-22.04
 
 
-# 123123321
+# 123123321123
 
 jobs:
   auto-merge:


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-22.02` to create a PR keeping `branch-22.04` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.