### PR TITLE
[auto-merge] bot-auto-merge-release/25.08 to main [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-      - branch-*
+      - release/*
     types: [closed]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This repository contains native support code for the
 [RAPIDS Accelerator for Apache Spark](https://github.com/NVIDIA/spark-rapids).
 
+
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/spark-rapids-jni)
 
 ## Building From Source

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RAPIDS Accelerator JNI For Apache Spark
 
 
+
 This repository contains native support code for the
 [RAPIDS Accelerator for Apache Spark](https://github.com/NVIDIA/spark-rapids).
 


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-release/25.08` to create a PR keeping `main` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.